### PR TITLE
updating appsettings.json

### DIFF
--- a/appsettings.json
+++ b/appsettings.json
@@ -6,7 +6,14 @@
     }
   },
   "AllowedHosts": "*",
-    "ConnectionStrings": {
-      "DefaultConnection": "Server=localhost;Database=elearning_db;User=root;Password=dhondhu;"
+  "Kestrel": {
+    "Endpoints": {
+      "Http": {
+        "Url": "http://0.0.0.0:5000"
+      }
     }
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=localhost;Database=elearning_db;User=root;Password=dhondhu;"
+  }
 }


### PR DESCRIPTION
By default, .NET applications listen on localhost (127.0.0.1), which means you cannot access it from another machine or through a public IP.

We can also run the app through explicit binding.

**dotnet ElearnBackend.dll --urls "http://0.0.0.0:5000"**

To avoid that, I have updated the appsettings.json file to bind all network interfaces(0.0.0.0)